### PR TITLE
Jasonboukheir/feat/burst compiled delegates

### DIFF
--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using Unity.Burst;
+using static CareBoo.Burst.Delegates.SafetyChecks;
+
+namespace CareBoo.Burst.Delegates
+{
+    public struct BurstAction
+        : IAction
+    {
+        readonly FunctionPointer<Action> fPtr;
+
+        public BurstAction(FunctionPointer<Action> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke()
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke();
+        }
+    }
+
+    public struct BurstAction<T>
+        : IAction<T>
+        where T : struct
+    {
+        readonly FunctionPointer<Action<T>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0);
+        }
+    }
+
+    public struct BurstAction<T, U>
+        : IAction<T, U>
+        where T : struct
+        where U : struct
+    {
+        readonly FunctionPointer<Action<T, U>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1);
+        }
+    }
+
+    public struct BurstAction<T, U, V>
+        : IAction<T, U, V>
+        where T : struct
+        where U : struct
+        where V : struct
+    {
+        readonly FunctionPointer<Action<T, U, V>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U, V>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1, V arg2)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1, arg2);
+        }
+    }
+
+    public struct BurstAction<T, U, V, W>
+        : IAction<T, U, V, W>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+    {
+        readonly FunctionPointer<Action<T, U, V, W>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U, V, W>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1, V arg2, W arg3)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1, arg2, arg3);
+        }
+    }
+
+    public struct BurstAction<T, U, V, W, X>
+        : IAction<T, U, V, W, X>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+    {
+        readonly FunctionPointer<Action<T, U, V, W, X>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U, V, W, X>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1, arg2, arg3, arg4);
+        }
+    }
+
+    public struct BurstAction<T, U, V, W, X, Y>
+        : IAction<T, U, V, W, X, Y>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+        where Y : struct
+    {
+        readonly FunctionPointer<Action<T, U, V, W, X, Y>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U, V, W, X, Y>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
+    public struct BurstAction<T, U, V, W, X, Y, Z>
+        : IAction<T, U, V, W, X, Y, Z>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+        where Y : struct
+        where Z : struct
+    {
+        readonly FunctionPointer<Action<T, U, V, W, X, Y, Z>> fPtr;
+
+        public BurstAction(FunctionPointer<Action<T, U, V, W, X, Y, Z>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
+        {
+            SupportedInBurstOnly();
+            fPtr.Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+    }
+
+}

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.cs.meta
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5a7fbb540a6a7e49a1e5028d4d71900
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using Unity.Burst;
+using static CareBoo.Burst.Delegates.SafetyChecks;
+
+namespace CareBoo.Burst.Delegates
+{
+    public struct BurstFunc<TResult>
+        : IFunc<TResult>
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke()
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke();
+        }
+    }
+
+    public struct BurstFunc<T, TResult>
+        : IFunc<T, TResult>
+        where T : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0);
+        }
+    }
+
+    public struct BurstFunc<T, U, TResult>
+        : IFunc<T, U, TResult>
+        where T : struct
+        where U : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1);
+        }
+    }
+
+    public struct BurstFunc<T, U, V, TResult>
+        : IFunc<T, U, V, TResult>
+        where T : struct
+        where U : struct
+        where V : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, V, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, V, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1, V arg2)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1, arg2);
+        }
+    }
+
+    public struct BurstFunc<T, U, V, W, TResult>
+        : IFunc<T, U, V, W, TResult>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, V, W, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, V, W, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1, V arg2, W arg3)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1, arg2, arg3);
+        }
+    }
+
+    public struct BurstFunc<T, U, V, W, X, TResult>
+        : IFunc<T, U, V, W, X, TResult>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, V, W, X, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, V, W, X, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1, arg2, arg3, arg4);
+        }
+    }
+
+    public struct BurstFunc<T, U, V, W, X, Y, TResult>
+        : IFunc<T, U, V, W, X, Y, TResult>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+        where Y : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, V, W, X, Y, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, V, W, X, Y, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
+    public struct BurstFunc<T, U, V, W, X, Y, Z, TResult>
+        : IFunc<T, U, V, W, X, Y, Z, TResult>
+        where T : struct
+        where U : struct
+        where V : struct
+        where W : struct
+        where X : struct
+        where Y : struct
+        where Z : struct
+        where TResult : struct
+    {
+        readonly FunctionPointer<Func<T, U, V, W, X, Y, Z, TResult>> fPtr;
+
+        public BurstFunc(FunctionPointer<Func<T, U, V, W, X, Y, Z, TResult>> fPtr)
+        {
+            this.fPtr = fPtr;
+        }
+
+        public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
+        {
+            SupportedInBurstOnly();
+            return fPtr.Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+    }
+
+}

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.cs.meta
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8360c24a94513e242ae505281d30a262
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/CareBoo.Burst.Delegates.asmdef
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/CareBoo.Burst.Delegates.asmdef
@@ -1,6 +1,8 @@
 {
     "name": "CareBoo.Burst.Delegates",
-    "references": [],
+    "references": [
+        "Unity.Burst"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/SafetyChecks.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/SafetyChecks.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Unity.Burst;
+
+namespace CareBoo.Burst.Delegates
+{
+    internal static class SafetyChecks
+    {
+        [BurstDiscard]
+        public static void SupportedInBurstOnly()
+        {
+            throw new NotSupportedException($"Usage of BurstAction and BurstFunc is only supported in Burst-compiled code.");
+        }
+    }
+}

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/SafetyChecks.cs.meta
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/SafetyChecks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 986f2e8fbfd2ec3428afcaa6b6c4987b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/ValueAction.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/ValueAction.cs
@@ -1,4 +1,7 @@
-﻿namespace CareBoo.Burst.Delegates
+﻿using System;
+using Unity.Burst;
+
+namespace CareBoo.Burst.Delegates
 {
     public struct ValueAction
     {
@@ -22,6 +25,13 @@
             where TLambda : struct, IAction
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstAction> Compile(Action action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -48,6 +58,13 @@
             where TLambda : struct, IAction<T>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstAction<T>> Compile(Action<T> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -76,6 +93,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstAction<T, U>> Compile(Action<T, U> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueAction<T, U, V>
@@ -103,6 +127,13 @@
             where TLambda : struct, IAction<T, U, V>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstAction<T, U, V>> Compile(Action<T, U, V> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U, V>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -133,6 +164,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstAction<T, U, V, W>> Compile(Action<T, U, V, W> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U, V, W>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueAction<T, U, V, W, X>
@@ -162,6 +200,13 @@
             where TLambda : struct, IAction<T, U, V, W, X>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstAction<T, U, V, W, X>> Compile(Action<T, U, V, W, X> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U, V, W, X>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -194,6 +239,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstAction<T, U, V, W, X, Y>> Compile(Action<T, U, V, W, X, Y> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U, V, W, X, Y>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueAction<T, U, V, W, X, Y, Z>
@@ -225,6 +277,13 @@
             where TLambda : struct, IAction<T, U, V, W, X, Y, Z>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstAction<T, U, V, W, X, Y, Z>> Compile(Action<T, U, V, W, X, Y, Z> action)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(action);
+            var burstAction = new BurstAction<T, U, V, W, X, Y, Z>(fPtr);
+            return New(burstAction);
         }
     }
 }

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/ValueFunc.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/ValueFunc.cs
@@ -1,4 +1,7 @@
-﻿namespace CareBoo.Burst.Delegates
+﻿using System;
+using Unity.Burst;
+
+namespace CareBoo.Burst.Delegates
 {
     public struct ValueFunc<TResult>
         where TResult : struct
@@ -23,6 +26,13 @@
             where TLambda : struct, IFunc<TResult>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstFunc<TResult>> Compile(Func<TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<TResult>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -50,6 +60,13 @@
             where TLambda : struct, IFunc<T, TResult>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstFunc<T, TResult>> Compile(Func<T, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, TResult>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -79,6 +96,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstFunc<T, U, TResult>> Compile(Func<T, U, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, TResult>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueFunc<T, U, V, TResult>
@@ -107,6 +131,13 @@
             where TLambda : struct, IFunc<T, U, V, TResult>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstFunc<T, U, V, TResult>> Compile(Func<T, U, V, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, V, TResult>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -138,6 +169,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstFunc<T, U, V, W, TResult>> Compile(Func<T, U, V, W, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, V, W, TResult>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueFunc<T, U, V, W, X, TResult>
@@ -168,6 +206,13 @@
             where TLambda : struct, IFunc<T, U, V, W, X, TResult>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstFunc<T, U, V, W, X, TResult>> Compile(Func<T, U, V, W, X, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, V, W, X, TResult>(fPtr);
+            return New(burstAction);
         }
     }
 
@@ -201,6 +246,13 @@
         {
             return new Struct<TLambda>(lambda);
         }
+
+        public static Struct<BurstFunc<T, U, V, W, X, Y, TResult>> Compile(Func<T, U, V, W, X, Y, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, V, W, X, Y, TResult>(fPtr);
+            return New(burstAction);
+        }
     }
 
     public struct ValueFunc<T, U, V, W, X, Y, Z, TResult>
@@ -233,6 +285,13 @@
             where TLambda : struct, IFunc<T, U, V, W, X, Y, Z, TResult>
         {
             return new Struct<TLambda>(lambda);
+        }
+
+        public static Struct<BurstFunc<T, U, V, W, X, Y, Z, TResult>> Compile(Func<T, U, V, W, X, Y, Z, TResult> func)
+        {
+            var fPtr = BurstCompiler.CompileFunctionPointer(func);
+            var burstAction = new BurstFunc<T, U, V, W, X, Y, Z, TResult>(fPtr);
+            return New(burstAction);
         }
     }
 }


### PR DESCRIPTION
Adds `FunctionPointer`-backed structs for `ValueFunc` and `ValueAction`.

`BurstFunc` and `BurstAction` are only supported in Burst-compiled code.