### PR TITLE
feat: :sparkles: Introduce working generic FuncPointer

### DIFF
--- a/.github/workflows/activation.yaml
+++ b/.github/workflows/activation.yaml
@@ -1,12 +1,12 @@
 name: Acquire Unity Activation File
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       unityVersion:
         description: 'Unity Version to request an activation file from.'
         required: true
-  
+
 jobs:
   activation:
     name: Request manual activation file 🔑
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Request manual activation file
       id: getManualLicenseFile
-      uses: webbertakken/unity-request-manual-activation-file@v1.1
+      uses: game-ci/unity-request-activation-file@v2.0-alpha-1
       with:
         unityVersion: ${{ github.event.inputs.unityVersion }}
     - name: Expose as artifact

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2020_1 }}
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2020_2_0 }}
 
 jobs:
   testAllModes:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         projectPath:
           - .
         unityVersion:
-          - 2020.1.10f1
+          - 2020.2.0f1
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
             Library-
       - run: ./scripts/coverageAssemblyFilters
         id: assemblyFilters
-      - uses: webbertakken/unity-test-runner@v1.7
+      - uses: game-ci/unity-test-runner@v2.0-alpha-1
         id: tests
         with:
           projectPath: ${{ matrix.projectPath }}

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates.Tests/BurstDelegateTest.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates.Tests/BurstDelegateTest.cs
@@ -39,18 +39,10 @@ internal class BurstDelegateTests
         using (var input = new NativeArray<int>(new int[1], Allocator.Persistent))
         using (var output = new NativeArray<int>(new int[1], Allocator.Persistent))
         {
-            if (!BurstCompiler.IsEnabled || !BurstCompiler.Options.IsEnabled || !BurstCompiler.Options.EnableBurstCompilation)
-            {
-                LogAssert.Expect(UnityEngine.LogType.Error, new Regex("BurstFunc"));
-                new CallFuncJob { Func = Add4Func, Input = input, Output = output }.Run();
-            }
-            else
-            {
-                var expected = Add4(input[0]);
-                new CallFuncJob { Func = Add4Func, Input = input, Output = output }.Run();
-                var actual = output[0];
-                Assert.AreEqual(expected, actual);
-            }
+            var expected = Add4(input[0]);
+            new CallFuncJob { Func = Add4Func, Input = input, Output = output }.Run();
+            var actual = output[0];
+            Assert.AreEqual(expected, actual);
         }
     }
 
@@ -60,8 +52,9 @@ internal class BurstDelegateTests
         using (var input = new NativeArray<int>(new int[1], Allocator.Persistent))
         using (var output = new NativeArray<int>(new int[1], Allocator.Persistent))
         {
-            LogAssert.Expect(UnityEngine.LogType.Error, new Regex("BurstFunc"));
-            Add4Func.Invoke(input[0]);
+            var expected = Add4(input[0]);
+            var actual = Add4Func.Invoke(input[0]);
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.gen.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.gen.cs
@@ -13,7 +13,6 @@
 
 using System;
 using Unity.Burst;
-using UnityEngine;
 
 namespace CareBoo.Burst.Delegates
 {
@@ -23,32 +22,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke()
         {
             CheckBurst();
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke();
         }
 
         [BurstDiscard]
         private void CheckBurst()
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action>.GetDelegate(functionPointer.Value).Invoke();
         }
 
         public static BurstAction Compile(Action action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action>.SetDelegate(functionPointer.Value, action);
             return new BurstAction(functionPointer);
         }
 
@@ -70,32 +71,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0)
         {
-            CheckBurst();
+            CheckBurst(arg0);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T>>.GetDelegate(functionPointer.Value).Invoke(arg0);
         }
 
         public static BurstAction<T> Compile(Action<T> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T>(functionPointer);
         }
 
@@ -118,32 +121,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1);
         }
 
         public static BurstAction<T, U> Compile(Action<T, U> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U>(functionPointer);
         }
 
@@ -167,32 +172,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U, V>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U, V>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1, V arg2)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1, arg2);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U, V>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2);
         }
 
         public static BurstAction<T, U, V> Compile(Action<T, U, V> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U, V>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U, V>(functionPointer);
         }
 
@@ -217,32 +224,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U, V, W>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U, V, W>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1, V arg2, W arg3)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1, arg2, arg3);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U, V, W>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3);
         }
 
         public static BurstAction<T, U, V, W> Compile(Action<T, U, V, W> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U, V, W>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U, V, W>(functionPointer);
         }
 
@@ -268,32 +277,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U, V, W, X>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U, V, W, X>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U, V, W, X>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4);
         }
 
         public static BurstAction<T, U, V, W, X> Compile(Action<T, U, V, W, X> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U, V, W, X>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U, V, W, X>(functionPointer);
         }
 
@@ -320,32 +331,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U, V, W, X, Y>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U, V, W, X, Y>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4, arg5);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U, V, W, X, Y>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static BurstAction<T, U, V, W, X, Y> Compile(Action<T, U, V, W, X, Y> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U, V, W, X, Y>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U, V, W, X, Y>(functionPointer);
         }
 
@@ -373,32 +386,34 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Action<T, U, V, W, X, Y, Z>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<T, U, V, W, X, Y, Z>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<T, U, V, W, X, Y, Z>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         public static BurstAction<T, U, V, W, X, Y, Z> Compile(Action<T, U, V, W, X, Y, Z> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<T, U, V, W, X, Y, Z>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<T, U, V, W, X, Y, Z>(functionPointer);
         }
 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.tt
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstAction.tt
@@ -13,7 +13,6 @@
 
 using System;
 using Unity.Burst;
-using UnityEngine;
 
 namespace CareBoo.Burst.Delegates
 {
@@ -48,32 +47,34 @@ for (var i = 0; i < GENERIC_PARAMS.Length; i++)
     {
         readonly FunctionPointer<Action<#=GENERIC_DEF#>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
 
         public BurstAction(FunctionPointer<Action<#=GENERIC_DEF#>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
         }
 
         public void Invoke(<#=GENERIC_ARGS_TYPED#>)
         {
-            CheckBurst();
+            CheckBurst(<#=GENERIC_ARGS#>);
 
-            if (burstFlag)
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
+            if (burstEnabled)
                 functionPointer.Invoke(<#=GENERIC_ARGS#>);
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(<#=GENERIC_ARGS_TYPED#>)
         {
-            burstFlag = false;
-            Debug.LogError("BurstAction does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            DelegateCache<Action<#=GENERIC_DEF#>>.GetDelegate(functionPointer.Value).Invoke(<#=GENERIC_ARGS#>);
         }
 
         public static BurstAction<#=GENERIC_DEF#> Compile(Action<#=GENERIC_DEF#> action)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(action);
+            DelegateCache<Action<#=GENERIC_DEF#>>.SetDelegate(functionPointer.Value, action);
             return new BurstAction<#=GENERIC_DEF#>(functionPointer);
         }
 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.gen.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.gen.cs
@@ -13,7 +13,6 @@
 
 using System;
 using Unity.Burst;
-using UnityEngine;
 
 namespace CareBoo.Burst.Delegates
 {
@@ -24,33 +23,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke()
         {
             CheckBurst();
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke()
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke();
+            else
+                return value;
         }
 
         [BurstDiscard]
         private void CheckBurst()
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<TResult>>.GetDelegate(functionPointer.Value).Invoke();
         }
 
         public static BurstFunc<TResult> Compile(Func<TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<TResult>(functionPointer);
         }
 
@@ -73,33 +78,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0)
         {
-            CheckBurst();
+            CheckBurst(arg0);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0);
         }
 
         public static BurstFunc<T, TResult> Compile(Func<T, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, TResult>(functionPointer);
         }
 
@@ -123,33 +134,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1);
         }
 
         public static BurstFunc<T, U, TResult> Compile(Func<T, U, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, TResult>(functionPointer);
         }
 
@@ -174,33 +191,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, V, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, V, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1, V arg2)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1, arg2)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1, arg2);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, V, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2);
         }
 
         public static BurstFunc<T, U, V, TResult> Compile(Func<T, U, V, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, V, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, V, TResult>(functionPointer);
         }
 
@@ -226,33 +249,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, V, W, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, V, W, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1, V arg2, W arg3)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1, arg2, arg3)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1, arg2, arg3);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, V, W, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3);
         }
 
         public static BurstFunc<T, U, V, W, TResult> Compile(Func<T, U, V, W, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, V, W, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, V, W, TResult>(functionPointer);
         }
 
@@ -279,33 +308,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, V, W, X, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, V, W, X, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, V, W, X, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4);
         }
 
         public static BurstFunc<T, U, V, W, X, TResult> Compile(Func<T, U, V, W, X, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, V, W, X, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, V, W, X, TResult>(functionPointer);
         }
 
@@ -333,33 +368,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, V, W, X, Y, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, V, W, X, Y, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4, arg5);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, V, W, X, Y, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static BurstFunc<T, U, V, W, X, Y, TResult> Compile(Func<T, U, V, W, X, Y, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, V, W, X, Y, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, V, W, X, Y, TResult>(functionPointer);
         }
 
@@ -388,33 +429,39 @@ namespace CareBoo.Burst.Delegates
     {
         readonly FunctionPointer<Func<T, U, V, W, X, Y, Z, TResult>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<T, U, V, W, X, Y, Z, TResult>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
         {
-            CheckBurst();
+            CheckBurst(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<T, U, V, W, X, Y, Z, TResult>>.GetDelegate(functionPointer.Value).Invoke(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         public static BurstFunc<T, U, V, W, X, Y, Z, TResult> Compile(Func<T, U, V, W, X, Y, Z, TResult> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<T, U, V, W, X, Y, Z, TResult>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<T, U, V, W, X, Y, Z, TResult>(functionPointer);
         }
 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.tt
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/BurstFunc.tt
@@ -13,7 +13,6 @@
 
 using System;
 using Unity.Burst;
-using UnityEngine;
 
 namespace CareBoo.Burst.Delegates
 {
@@ -52,33 +51,39 @@ for (var i = 0; i < GENERIC_PARAMS.Length; i++)
     {
         readonly FunctionPointer<Func<#=GENERIC_DEF#>> functionPointer;
 
-        bool burstFlag;
+        bool burstEnabled;
+
+        TResult value;
 
         public BurstFunc(FunctionPointer<Func<#=GENERIC_DEF#>> functionPointer)
         {
             this.functionPointer = functionPointer;
-            burstFlag = true;
+            burstEnabled = true;
+            value = default;
         }
 
         public TResult Invoke(<#=GENERIC_ARGS_TYPED#>)
         {
-            CheckBurst();
+            CheckBurst(<#=GENERIC_ARGS#>);
+            Unity.Burst.CompilerServices.Hint.Assume(burstEnabled);
 
-            return burstFlag
-                ? functionPointer.Invoke(<#=GENERIC_ARGS#>)
-                : default;
+            if (burstEnabled)
+                return functionPointer.Invoke(<#=GENERIC_ARGS#>);
+            else
+                return value;
         }
 
         [BurstDiscard]
-        private void CheckBurst()
+        private void CheckBurst(<#=GENERIC_ARGS_TYPED#>)
         {
-            burstFlag = false;
-            Debug.LogError("BurstFunc does not support being run outside burst-compiled code.");
+            burstEnabled = false;
+            value = DelegateCache<Func<#=GENERIC_DEF#>>.GetDelegate(functionPointer.Value).Invoke(<#=GENERIC_ARGS#>);
         }
 
         public static BurstFunc<#=GENERIC_DEF#> Compile(Func<#=GENERIC_DEF#> func)
         {
             var functionPointer = BurstCompiler.CompileFunctionPointer(func);
+            DelegateCache<Func<#=GENERIC_DEF#>>.SetDelegate(functionPointer.Value, func);
             return new BurstFunc<#=GENERIC_DEF#>(functionPointer);
         }
 

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/DelegateCache.cs
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/DelegateCache.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace CareBoo.Burst.Delegates
+{
+    public static class DelegateCache<T> where T : Delegate
+    {
+        private static Dictionary<IntPtr, T> dict;
+        private static Dictionary<IntPtr, T> Dict => dict ??= new Dictionary<IntPtr, T>();
+
+        public static T GetDelegate(IntPtr ptr) => Dict[ptr];
+
+        public static void SetDelegate(IntPtr ptr, T d)
+        {
+            Dict[ptr] = d;
+        }
+    }
+}

--- a/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/DelegateCache.cs.meta
+++ b/Packages/com.careboo.burst-delegates/CareBoo.Burst.Delegates/DelegateCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faffdb35a6a5aa34494bc6192bf2bc49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.burst": "1.4.3",
+    "com.unity.burst": "1.5.0-pre.3",
     "com.unity.entities": "0.16.0-preview.21",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.package-validation-suite": "0.18.1-preview",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {}
     },
     "com.unity.burst": {
-      "version": "1.4.3",
+      "version": "1.5.0-pre.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.1.17f1
-m_EditorVersionWithRevision: 2020.1.17f1 (9957aee8edc2)
+m_EditorVersion: 2020.2.0f1
+m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)


### PR DESCRIPTION
Using some compiler hints, it's possible to have a generic function pointer. You just need a cache to store the c# reference of the function pointer when you call `Compile`.